### PR TITLE
Read e-mail password from terminal

### DIFF
--- a/sendKindle.py
+++ b/sendKindle.py
@@ -23,6 +23,7 @@ Author: Kamil Páral <kamil.paral /at/ gmail.com>
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import ConfigParser
+import getpass
 import optparse
 import os
 import smtplib
@@ -115,7 +116,9 @@ convert = False'''
             if config.has_option('Default', 'smtp_password'):
                 # prefer value from cmdline option
                 self.smtp_password = (self.smtp_password or
-                                      config.get('Default', 'smtp_password'))
+                                      config.get('Default', 'smtp_password') or
+                                      getpass.getpass('Password for %s: ' %
+                                                            self.user_email))
             if config.has_option('Default', 'convert'):
                 # prefer value from cmdline option
                 self.convert = (self.convert or


### PR DESCRIPTION
Read e-mail password from terminal if none is provided from
configuration file or as command line parameter.
